### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: "Tag for the release"
         required: true
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -20,3 +24,4 @@ jobs:
     uses: step-security/reusable-workflows/.github/workflows/actions_release.yaml@v1
     with:
       tag: "${{ github.event.inputs.tag }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -11,6 +11,10 @@ on:
         description: "Specify a base branch"
         required: false
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -20,6 +24,7 @@ jobs:
     with:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -7,6 +7,10 @@ on:
         description: "Base branch to create the PR against"
         required: true
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: write
@@ -21,3 +25,4 @@ jobs:
       original-owner: "Bhacaz"
       repo-name: "docs-as-code-confluence"
       base_branch: ${{ inputs.base_branch }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Docs as Code - Confluence
 
 Publish a folder of documentation to Confluence.

--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     description: "Page id under which the documentation will be published"
     required: true
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -29016,6 +29016,7 @@ const Confluence = __nccwpck_require__(3099);
 const core = __nccwpck_require__(2186);
 const parser = __nccwpck_require__(4363)
 const path = __nccwpck_require__(1017)
+const fs = __nccwpck_require__(7147)
 const axios = __nccwpck_require__(8757)
 
 const filesStructure = __nccwpck_require__(8612);
@@ -29086,19 +29087,48 @@ async function handleAttachments(contentPageId, data) {
 }
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "Bhacaz/docs-as-code-confluence";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const Confluence = require("confluence-api");
 const core = require("@actions/core");
 const parser = require("node-html-parser")
 const path = require('path')
+const fs = require('fs')
 const axios = require('axios')
 
 const filesStructure = require("./utils/files");
@@ -72,19 +73,48 @@ async function handleAttachments(contentPageId, data) {
 }
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "Bhacaz/docs-as-code-confluence";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
-      console.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jest": "^29.7.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "step-security",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "dependencies": {
     "@actions/core": "^1.6.0",


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z